### PR TITLE
Add Compass component config (compass.yml)

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -1,0 +1,8 @@
+name: API-Documentation
+id: ari:cloud:compass:4337fc0d-aa55-4ff9-bd75-ef7117ff9381:component/4c6fdffe-fa4a-46ef-9e6f-a1aa05480c89/8226eb0e-130a-45b8-b765-44177bd94887
+configVersion: 1
+typeId: OTHER
+ownerId: ari:cloud:identity::team/e8f7674c-a0e6-405d-a5ba-8cd4fce918d1 # API Support
+links:
+  - type: REPOSITORY
+    url: https://github.com/EENCloud/API-Documentation


### PR DESCRIPTION
Onboards `API-Documentation` to Compass (replaces the stale compass-github-importer PR).

- typeId: `OTHER`
- owner: API Support
- component: `8226eb0e-130a-45b8-b765-44177bd94887`